### PR TITLE
doc: fix yarn syntax - cwd must be first

### DIFF
--- a/docs/advanced/create-service-software-template.md
+++ b/docs/advanced/create-service-software-template.md
@@ -12,7 +12,7 @@ By doing so, it enables and configures the PagerDuty Card provided by the fronte
     If you were already using the scaffolder actions before this, follow the migration guide [here](/backstage-plugin-docs/advanced/backend-system-migration) as you need to update the package used in the code.
 
 ```bash
-yarn add --cwd packages/backend @pagerduty/backstage-plugin-scaffolder-actions # (1)!
+yarn --cwd packages/backend add @pagerduty/backstage-plugin-scaffolder-actions # (1)!
 ```
 
 1. This command adds `@pagerduty/backstage-plugin-scaffolder` package to the `packages/backend` folder because it is a backend module.
@@ -137,7 +137,7 @@ Once all the information is provided by the user we will:
     The UI component that allows users to select the *Escalation Policy* when creating a new service in PagerDuty depends on an open source component. For the template to work properly please install it before.
 
     ```bash
-    yarn add --cwd packages/app @roadiehq/plugin-scaffolder-frontend-module-http-request-field
+    yarn --cwd packages/app add @roadiehq/plugin-scaffolder-frontend-module-http-request-field
     ```
 
     Once it is installed, go to `/packages/app/src/App.tsx` and find `<ScaffolderPage />`. Add the UI component to `ScaffolderFieldExtensions`. It should look like this when you finish.

--- a/docs/advanced/service-entity-mapping.md
+++ b/docs/advanced/service-entity-mapping.md
@@ -13,7 +13,7 @@ For that reason we create a `PagerDutyPage` component that is intended to be the
 In order to set this up in your Backstage instance you should install the necessary packages first by running the following command. This command will install the entity processor module that we will configure later on.
 
 ```bash
-yarn add --cwd packages/backend @pagerduty/backstage-plugin-entity-processor
+yarn --cwd packages/backend add @pagerduty/backstage-plugin-entity-processor
 ```
 
 !!! note

--- a/docs/getting-started/backstage.md
+++ b/docs/getting-started/backstage.md
@@ -11,13 +11,13 @@
 To install the PagerDuty plugin into Backstage run the following commands from your Backstage root directory.
 
 ```bash
-yarn add --cwd packages/app @pagerduty/backstage-plugin # (1)!
+yarn --cwd packages/app add @pagerduty/backstage-plugin # (1)!
 ```
 
 1. This command adds `@pagerduty/backstage-plugin` package to the `packages/app` folder because it is a frontend plugin.
 
 ```bash
-yarn add --cwd packages/backend @pagerduty/backstage-plugin-backend # (1)!
+yarn --cwd packages/backend add @pagerduty/backstage-plugin-backend # (1)!
 ```
 
 1. This command adds `@pagerduty/backstage-plugin-backend` package to the `packages/backend` folder because it is a backend plugin.

--- a/docs/migration/from-backstage-owned.md
+++ b/docs/migration/from-backstage-owned.md
@@ -13,7 +13,7 @@ If you are migrating from the PagerDuty plugin that was maintained by Backstage 
 
     ```bash
     # From your Backstage root directory
-    yarn add --cwd packages/app @pagerduty/backstage-plugin @pagerduty/backstage-plugin-common
+    yarn --cwd packages/app add @pagerduty/backstage-plugin @pagerduty/backstage-plugin-common
     ```
 
 3. Replace all occurrences of `@backstage/plugin-pagerduty` with `@pagerduty/backstage-plugin` in your components
@@ -21,7 +21,7 @@ If you are migrating from the PagerDuty plugin that was maintained by Backstage 
 4. Install the backend PagerDuty plugin for Backstage
 
     ```bash
-    yarn add --cwd packages/backend @pagerduty/backstage-plugin-backend @pagerduty/backstage-plugin-common
+    yarn --cwd packages/backend add @pagerduty/backstage-plugin-backend @pagerduty/backstage-plugin-common
     ```
 
 5. [Add the backend plugin](/backstage-plugin-docs/getting-started/backstage/#add-the-backend-plugin-to-your-application) to your Backstage project

--- a/docs/release-notes/backend.md
+++ b/docs/release-notes/backend.md
@@ -193,7 +193,7 @@ This release adds support to the new [Backstage backend system](https://backstag
 1. Install new package
 
     ```bash
-    yarn add --cwd packages/backend @pagerduty/backstage-plugin-scaffolder-actions
+    yarn --cwd packages/backend add @pagerduty/backstage-plugin-scaffolder-actions
     yarn install
     ```
 
@@ -220,14 +220,14 @@ This release adds support to the new [Backstage backend system](https://backstag
 1. Install new package
 
     ```bash
-    yarn add --cwd packages/backend @pagerduty/backstage-plugin-scaffolder-actions
+    yarn --cwd packages/backend add @pagerduty/backstage-plugin-scaffolder-actions
     yarn install
     ```
 
 2. **(Optional)** If this is the first time configuring PagerDuty's plugin you also need the following packages
 
     ```bash
-    yarn add --cwd packages/backend @pagerduty/backstage-plugin-backend @pagerduty/backstage-plugin-common
+    yarn --cwd packages/backend add @pagerduty/backstage-plugin-backend @pagerduty/backstage-plugin-common
     yarn install
     ```
 

--- a/docs/release-notes/scaffolder-actions.md
+++ b/docs/release-notes/scaffolder-actions.md
@@ -71,7 +71,7 @@ By adding support for the new backend system, we were forced to isolate the exis
 1. Install new package
 
     ```bash
-    yarn add --cwd packages/backend @pagerduty/backstage-plugin-scaffolder-actions
+    yarn --cwd packages/backend add @pagerduty/backstage-plugin-scaffolder-actions
     yarn install
     ```
 
@@ -98,14 +98,14 @@ By adding support for the new backend system, we were forced to isolate the exis
 1. Install new package
 
     ```bash
-    yarn add --cwd packages/backend @pagerduty/backstage-plugin-scaffolder-actions
+    yarn --cwd packages/backend add @pagerduty/backstage-plugin-scaffolder-actions
     yarn install
     ```
 
 2. **(Optional)** If this is the first time configuring PagerDuty's plugin you also need the following packages
 
     ```bash
-    yarn add --cwd packages/backend @pagerduty/backstage-plugin-backend @pagerduty/backstage-plugin-common
+    yarn --cwd packages/backend add @pagerduty/backstage-plugin-backend @pagerduty/backstage-plugin-common
     yarn install
     ```
 


### PR DESCRIPTION
Newer Yarn requires the `--cwd` option comes before the command.

```
$ yarn add --cwd packages/app @pagerduty/backstage-plugin
Usage Error: The --cwd option is ambiguous when used anywhere else than
the very first parameter provided in the command line, before even the
command path
```

Signed-off-by: Robin H. Johnson <rjohnson@coreweave.com>
