### PR TITLE
feat: DEVECO-539 Add entity processor documentation

### DIFF
--- a/docs/advanced/configure-service-dependency-sync.md
+++ b/docs/advanced/configure-service-dependency-sync.md
@@ -4,6 +4,9 @@ The PagerDuty plugin allows users who use Backstage as their service catalog to 
 
 This feature is very powerful for users that want to leverage [PagerDuty Status Pages](https://www.pagerduty.com/platform/business-ops/status-pages/) properly but are limited by the fact that they don't have service dependencies configured in PagerDuty. With this feature, the plugin will do this automatically for you.
 
+!!! warning
+    This feature requires the [Entity Processor](entity-processor.md) module to be installed — without it, dependency sync will not run.
+
 !!! note
     Only the Backstage entities that have corresponding services in PagerDuty will get their service dependencies mapped. This feature is powered by the `CatalogProcessor` and therefore if you make changes on your Backstage entity configuration they will, in time, be mapped to PagerDuty.
 

--- a/docs/advanced/entity-processor.md
+++ b/docs/advanced/entity-processor.md
@@ -1,0 +1,58 @@
+# Entity Processor
+
+The PagerDuty plugin for Backstage is made up of three packages: the frontend plugin (`@pagerduty/backstage-plugin`), the backend plugin (`@pagerduty/backstage-plugin-backend`), and the **Entity Processor** module (`@pagerduty/backstage-plugin-entity-processor`).
+
+The frontend and backend plugins are **required** for the plugin to work at all. The Entity Processor is **optional, but highly recommended** — most of the plugin's synchronization capabilities depend on it.
+
+## What does it do?
+
+The Entity Processor is a Backstage catalog backend module. It hooks into Backstage's catalog processing pipeline and, for every relevant entity, reconciles PagerDuty-related configuration into that entity's catalog data as it's processed.
+
+## Do you need it?
+
+There are two ways to define a mapping between a PagerDuty service and a Backstage entity:
+
+1. **Statically, in the entity's `catalog-info.yaml`**, using annotations such as `pagerduty.com/service-id`. These annotations are read directly by the frontend plugin regardless of whether the Entity Processor is installed.
+2. **Dynamically, using the `/pagerduty` page's service mapping UI**. Mappings created this way are persisted only to the Backstage database — they are **not** written to `catalog-info.yaml`. The Entity Processor is the only component that reads these database-stored mappings and applies them to the corresponding Backstage entity.
+
+If the Entity Processor is **not installed**, the plugin only works with mappings defined directly in YAML. A mapping created through the `/pagerduty` UI will be saved to the database, but it will never be synced onto the actual entity — so it will silently not work.
+
+## What doesn't work without it
+
+Without the Entity Processor installed:
+
+- **Service mappings created via the `/pagerduty` UI page never take effect.** The mapping is stored in the database but never applied to the Backstage entity. Mappings defined in `catalog-info.yaml` are unaffected and continue to work.
+- **[Service dependency sync](configure-service-dependency-sync.md) does not run.** Dependencies are never synced between Backstage and PagerDuty in either direction.
+- **Custom field sync to PagerDuty does not run.** Backstage entity data mapped to PagerDuty Custom Fields is never pushed.
+- YAML-defined mappings are never backfilled into the database, so mapping-status bookkeeping (e.g. the "in sync" / "out of sync" indicators on the `/pagerduty` page) won't reflect them accurately.
+
+## Installing dependencies
+
+In order to set this up in your Backstage instance you should install the necessary package first by running the following command.
+
+```bash
+yarn --cwd packages/backend add @pagerduty/backstage-plugin-entity-processor
+```
+
+!!! note
+    The following instructions assume that you already installed the frontend and backend plugin as described in the [Getting Started page](/backstage-plugin-docs/getting-started/backstage).
+
+## Configuring the Entity Processor
+
+The Entity Processor module is one of the key components of this capability as it allows for entity mapping configurations that were persisted into the Backstage database to be applied to each Backstage entity configuration.
+
+You can enable the entity processor in your Backstage instance by injecting the dependency in the backend system in `packages/backend/index.ts`.
+
+```typescript
+  import { createBackend } from '@backstage/backend-defaults';
+
+  const backend = createBackend();
+  
+  ...
+
+  backend.add(import('@pagerduty/backstage-plugin-entity-processor')); // <-- This is the line you want to add
+  
+  backend.start();
+```
+
+And that is it for the entity processor module. This module will process all Backstage entities and if there are any changes persisted to the database they will be applied automatically.

--- a/docs/advanced/service-entity-mapping.md
+++ b/docs/advanced/service-entity-mapping.md
@@ -6,36 +6,11 @@ This can of course be automated through the use of PagerDuty's APIs but it's sti
 
 For that reason, we created a `PagerDutyPage` component that is intended to be the single place for advanced configurations related to this plugin.
 
-## Installing dependencies
-
-In order to set this up in your Backstage instance you should install the necessary packages first by running the following command. This command will install the entity processor module that we will configure later on.
-
-```bash
-yarn --cwd packages/backend add @pagerduty/backstage-plugin-entity-processor
-```
+!!! note
+    This capability relies on the **Entity Processor** module. See [Entity Processor](entity-processor.md) for what it does, whether you need it, and how to install it.
 
 !!! note
     The following instructions assume that you already installed the frontend and backend plugin as described in the [Getting Started page](/backstage-plugin-docs/getting-started/backstage).
-
-## Configuring the Entity Processor
-
-The Entity Processor module is one of the key components of this capability as it allows for entity mapping configurations that were persisted into the Backstage database to be applied to each Backstage entity configuration.
-
-You can enable the entity processor in your Backstage instance by injecting the dependency in the backend system in `packages/backend/index.ts`.
-
-```typescript
-  import { createBackend } from '@backstage/backend-defaults';
-
-  const backend = createBackend();
-  
-  ...
-
-  backend.add(import('@pagerduty/backstage-plugin-entity-processor')); // <-- This is the line you want to add
-  
-  backend.start();
-```
-
-And that is it for the entity processor module. This module will process all Backstage entities and if there are any changes persisted to the database they will be applied automatically.
 
 ## Adding the PagerDutyPage component
 

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -59,7 +59,7 @@ The mapping interface includes intelligent service suggestions, searchable drop-
 
 ![service-entity-mapping](images/service-entity-mapping.png)
 
-This feature leverages the entity processor module to make the necessary updates to each Backstage entity automatically. The searchable interface and intelligent suggestions help you quickly find and map services, especially useful for large service catalogs with hundreds or thousands of services. Admins can decide whether to make the necessary changes in source code to ensure the mapping stays in sync.
+This feature leverages the [Entity Processor](advanced/entity-processor.md) module to make the necessary updates to each Backstage entity automatically. The searchable interface and intelligent suggestions help you quickly find and map services, especially useful for large service catalogs with hundreds or thousands of services. Admins can decide whether to make the necessary changes in source code to ensure the mapping stays in sync.
 
 ### Sync service dependencies between Backstage and PagerDuty
 
@@ -69,6 +69,8 @@ The PagerDuty plugin allows users to keep service dependencies in sync between B
 
 This feature allows you to sync service dependencies from **Backstage to PagerDuty**, **PagerDuty to Backstage**, or **merge the dependencies from both sides**.
 
+This feature requires the [Entity Processor](advanced/entity-processor.md) module to be installed.
+
 ### Sync Backstage entity data to PagerDuty Custom Fields
 
 The PagerDuty plugin for Backstage allows Admins to map Backstage entity properties to PagerDuty Custom Fields, keeping your PagerDuty services enriched with up-to-date context from your Backstage catalog.
@@ -76,6 +78,8 @@ The PagerDuty plugin for Backstage allows Admins to map Backstage entity propert
 The mapping interface lets you define a field name and an entity path, so the right data — runbook links, team ownership, and more — flows automatically into PagerDuty during catalog processing.
 
 ![custom-field-mapping](images/custom-field-mapping.png)
+
+This feature requires the [Entity Processor](advanced/entity-processor.md) module to be installed.
 
 ## Backend
 

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -59,7 +59,10 @@ The mapping interface includes intelligent service suggestions, searchable drop-
 
 ![service-entity-mapping](images/service-entity-mapping.png)
 
-This feature leverages the [Entity Processor](advanced/entity-processor.md) module to make the necessary updates to each Backstage entity automatically. The searchable interface and intelligent suggestions help you quickly find and map services, especially useful for large service catalogs with hundreds or thousands of services. Admins can decide whether to make the necessary changes in source code to ensure the mapping stays in sync.
+The searchable interface and intelligent suggestions help you quickly find and map services, especially useful for large service catalogs with hundreds or thousands of services. Admins can decide whether to make the necessary changes in source code to ensure the mapping stays in sync.
+
+!!! warning
+    This feature requires the [Entity Processor](advanced/entity-processor.md) module to be installed — without it, mappings created here will not sync to your Backstage entities.
 
 ### Sync service dependencies between Backstage and PagerDuty
 
@@ -69,7 +72,8 @@ The PagerDuty plugin allows users to keep service dependencies in sync between B
 
 This feature allows you to sync service dependencies from **Backstage to PagerDuty**, **PagerDuty to Backstage**, or **merge the dependencies from both sides**.
 
-This feature requires the [Entity Processor](advanced/entity-processor.md) module to be installed.
+!!! warning
+    This feature requires the [Entity Processor](advanced/entity-processor.md) module to be installed — without it, dependency sync will not run.
 
 ### Sync Backstage entity data to PagerDuty Custom Fields
 
@@ -79,7 +83,8 @@ The mapping interface lets you define a field name and an entity path, so the ri
 
 ![custom-field-mapping](images/custom-field-mapping.png)
 
-This feature requires the [Entity Processor](advanced/entity-processor.md) module to be installed.
+!!! warning
+    This feature requires the [Entity Processor](advanced/entity-processor.md) module to be installed — without it, custom field sync will not run.
 
 ## Backend
 

--- a/docs/getting-started/backstage.md
+++ b/docs/getting-started/backstage.md
@@ -24,6 +24,27 @@ yarn --cwd packages/backend add @pagerduty/backstage-plugin-backend # (1)!
 
 **That's it!** Now it's time to add the plugin to Backstage and configure your services.
 
+## Installing the Entity Processor (recommended)
+
+The frontend and backend plugins installed above are all you need for the plugin's core functionality, such as showing PagerDuty data on services that are mapped through `catalog-info.yaml` annotations.
+
+However, most of the plugin's synchronization features — mapping services dynamically through the `/pagerduty` UI, [service dependency sync](/backstage-plugin-docs/advanced/configure-service-dependency-sync), and [custom field sync](/backstage-plugin-docs/capabilities/#sync-backstage-entity-data-to-pagerduty-custom-fields) — require an additional package called the **Entity Processor**.
+
+!!! note
+    The Entity Processor is optional, but **highly recommended** for most setups. See [Entity Processor](/backstage-plugin-docs/advanced/entity-processor) for a full explanation of what it does and what won't work without it.
+
+To install it, run the following command from your Backstage root directory.
+
+```bash
+yarn --cwd packages/backend add @pagerduty/backstage-plugin-entity-processor
+```
+
+Then enable it in `packages/backend/src/index.ts`:
+
+```typescript
+backend.add(import('@pagerduty/backstage-plugin-entity-processor'));
+```
+
 ## Add the frontend plugin to your application
 
 The frontend plugin needs to be added to your application, and currently, that requires some code changes to the Backstage application. We will do that by updating the `EntityPage.tsx` file in `packages/app/src/components/catalog`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,6 +79,7 @@ nav:
     - Enable read-only mode: advanced/enable-read-only-mode.md
     - Hide change events: advanced/hide-change-events.md
     - Hide on-call: advanced/hide-oncall.md
+    - Entity Processor: advanced/entity-processor.md
     - Mapping PagerDuty Services to Backstage Entities: advanced/service-entity-mapping.md
   - UI Components:
     - PagerDutyCard: components/pagerduty-card.md


### PR DESCRIPTION
## Summary
- Adds a new dedicated page (`docs/advanced/entity-processor.md`) explaining that the Entity Processor module is optional but highly recommended, the two ways to map PagerDuty services to Backstage entities (YAML vs. `/pagerduty` UI), and what silently breaks without it (dynamic service mappings, dependency sync, custom field sync)
- Cross-links to the new page from `service-entity-mapping.md`, `configure-service-dependency-sync.md`, `capabilities.md`, and `getting-started/backstage.md`
- Adds the page to the `mkdocs.yml` nav under Advanced

## Test plan
- [x] Verified `mkdocs build --strict` completes with no new errors/broken links
- [x] Manually reviewed rendered pages via `mkdocs serve`

JIRA: https://pagerduty.atlassian.net/browse/DEVECO-539

🤖 Generated with [Claude Code](https://claude.com/claude-code)