### PR TITLE
feat: DEVECO-539 Entity processor documentation

### DIFF
--- a/docs/advanced/entity-processor.md
+++ b/docs/advanced/entity-processor.md
@@ -33,7 +33,7 @@ The setup steps differ depending on whether you are running a self-hosted Backst
 !!! note
     The following instructions assume that you already installed the frontend and backend plugin as described in the [Getting Started page](/backstage-plugin-docs/getting-started/backstage).
 
-### Backstage
+### Self-hosted Backstage
 
 In a self-hosted Backstage instance you install the package and wire it into the backend system yourself.
 

--- a/docs/advanced/entity-processor.md
+++ b/docs/advanced/entity-processor.md
@@ -26,22 +26,24 @@ Without the Entity Processor installed:
 - **Custom field sync to PagerDuty does not run.** Backstage entity data mapped to PagerDuty Custom Fields is never pushed.
 - YAML-defined mappings are never backfilled into the database, so mapping-status bookkeeping (e.g. the "in sync" / "out of sync" indicators on the `/pagerduty` page) won't reflect them accurately.
 
-## Installing dependencies
+## Installing and configuring the Entity Processor
 
-In order to set this up in your Backstage instance you should install the necessary package first by running the following command.
+The setup steps differ depending on whether you are running a self-hosted Backstage instance or Backstage Portal. Follow the section that matches your environment.
+
+!!! note
+    The following instructions assume that you already installed the frontend and backend plugin as described in the [Getting Started page](/backstage-plugin-docs/getting-started/backstage).
+
+### Backstage
+
+In a self-hosted Backstage instance you install the package and wire it into the backend system yourself.
+
+First, install the package from your Backstage root directory.
 
 ```bash
 yarn --cwd packages/backend add @pagerduty/backstage-plugin-entity-processor
 ```
 
-!!! note
-    The following instructions assume that you already installed the frontend and backend plugin as described in the [Getting Started page](/backstage-plugin-docs/getting-started/backstage).
-
-## Configuring the Entity Processor
-
-The Entity Processor module is one of the key components of this capability as it allows for entity mapping configurations that were persisted into the Backstage database to be applied to each Backstage entity configuration.
-
-You can enable the entity processor in your Backstage instance by injecting the dependency in the backend system in `packages/backend/index.ts`.
+Then enable the Entity Processor by injecting the dependency in the backend system in `packages/backend/src/index.ts`.
 
 ```typescript
   import { createBackend } from '@backstage/backend-defaults';
@@ -55,4 +57,18 @@ You can enable the entity processor in your Backstage instance by injecting the 
   backend.start();
 ```
 
-And that is it for the entity processor module. This module will process all Backstage entities and if there are any changes persisted to the database they will be applied automatically.
+And that is it for the Entity Processor module. This module will process all Backstage entities and if there are any changes persisted to the database they will be applied automatically.
+
+### Backstage Portal
+
+Backstage Portal manages backend modules through its UI, so there are no code changes to make. After installing the package, you enable the module from the Portal admin interface.
+
+1. Install the `@pagerduty/backstage-plugin-entity-processor` package in your Portal instance.
+2. In the left navigation bar, go to **Plugins**.
+3. Select the **Catalog** plugin.
+4. Open the **Modules** tab.
+5. Locate the `@pagerduty/backstage-plugin-entity-processor` module and click **Manage module**.
+6. Click **Start**.
+7. Wait for the **Applying new configuration...** message to disappear.
+
+Once the configuration has been applied, the Entity Processor is active. It will process all Backstage entities and automatically apply any changes persisted to the database.

--- a/docs/getting-started/backstage.md
+++ b/docs/getting-started/backstage.md
@@ -35,7 +35,7 @@ However, most of the plugin's synchronization features — mapping services dyna
 
 The setup steps differ depending on whether you are running a self-hosted Backstage instance or Backstage Portal. Follow the section that matches your environment.
 
-#### Backstage
+#### Self-hosted Backstage
 
 Install it by running the following command from your Backstage root directory.
 

--- a/docs/getting-started/backstage.md
+++ b/docs/getting-started/backstage.md
@@ -33,7 +33,11 @@ However, most of the plugin's synchronization features — mapping services dyna
 !!! note
     The Entity Processor is optional, but **highly recommended** for most setups. See [Entity Processor](/backstage-plugin-docs/advanced/entity-processor) for a full explanation of what it does and what won't work without it.
 
-To install it, run the following command from your Backstage root directory.
+The setup steps differ depending on whether you are running a self-hosted Backstage instance or Backstage Portal. Follow the section that matches your environment.
+
+#### Backstage
+
+Install it by running the following command from your Backstage root directory.
 
 ```bash
 yarn --cwd packages/backend add @pagerduty/backstage-plugin-entity-processor
@@ -44,6 +48,18 @@ Then enable it in `packages/backend/src/index.ts`:
 ```typescript
 backend.add(import('@pagerduty/backstage-plugin-entity-processor'));
 ```
+
+#### Backstage Portal
+
+Backstage Portal manages backend modules through its UI, so there are no code changes to make. After installing the package, enable the module from the Portal admin interface.
+
+1. Install the `@pagerduty/backstage-plugin-entity-processor` package in your Portal instance.
+2. In the left navigation bar, go to **Plugins**.
+3. Select the **Catalog** plugin.
+4. Open the **Modules** tab.
+5. Locate the `@pagerduty/backstage-plugin-entity-processor` module and click **Manage module**.
+6. Click **Start**.
+7. Wait for the **Applying new configuration...** message to disappear.
 
 ## Add the frontend plugin to your application
 


### PR DESCRIPTION
## Summary

Documents the PagerDuty Entity Processor module for Backstage, covering both self-hosted Backstage and Backstage Portal installs.

- Add a dedicated **Entity Processor** advanced page explaining what it does, why it's needed, and what won't work without it.
- Add entity processor warnings/notes to the affected capabilities.
- Split the install/configure instructions into separate **Backstage** and **Backstage Portal** sections (Portal is enabled via the Plugins → Catalog → Modules UI, no code changes).

Applies to both `docs/advanced/entity-processor.md` and `docs/getting-started/backstage.md`.

## Jira

[DEVECO-539](https://pagerduty.atlassian.net/browse/DEVECO-539)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DEVECO-539]: https://pagerduty.atlassian.net/browse/DEVECO-539?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ